### PR TITLE
(feat) Added OriginalUrl.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,6 @@ extern crate http;
 extern crate iron;
 extern crate regex;
 
-pub use Mount = mount::Mount;
-
+pub use mount::{Mount, OriginalUrl};
 mod mount;
 


### PR DESCRIPTION
This commit adds OriginalUrl, a simple tuple-struct that contains the original,
unmodified path so that middleware which needs it can have access.

Fixes #12. Fixes #18 
