### PR TITLE
(cleanup) Tidy rust-url usage, restore old API.

### DIFF
--- a/examples/mount.rs
+++ b/examples/mount.rs
@@ -20,7 +20,7 @@ fn send_hello(_: &mut Request, res: &mut Response) -> Status {
 
 fn main() {
     let mut server: Server = Iron::new();
-    server.chain.link(Mount::new(&["blocked"], FromFn::new(intercept)));
+    server.chain.link(Mount::new("/blocked/", FromFn::new(intercept)));
     server.chain.link(FromFn::new(send_hello));
     server.listen(Ipv4Addr(127, 0, 0, 1), 3000);
 }


### PR DESCRIPTION
I've tidied up the use of `unwrap` on URL data. The `rust-url` library provides a number of useful guarantees. See: https://github.com/iron/static-file/pull/28.

Not sure if you want to keep the API change I made? Is `&[&str]` for routes preferred over `&str`? I figure using `Path` is ok, but haven't looked into Windows compatibility...

Don't merge yet, untested due to `Share` -> `Sync` problem in `rust-encoding`. Waiting on https://github.com/lifthrasiir/rust-encoding/issues/34.
