### PR TITLE
(fix) Error handlers in child handlers are now invoked correctly

### DIFF
--- a/src/mount.rs
+++ b/src/mount.rs
@@ -112,7 +112,14 @@ impl Handler for Mount {
             req.extensions.remove::<OriginalUrl, Url>();
         }
 
-        res
+        // Pass back if no error occuring invoking the err, or pass to the
+        // local error handler.
+        return match res {
+            Ok(resp) => Ok(resp),
+            Err(err) => {
+                let (resp, _) = matched.handler.catch(req, err);
+                Ok(resp)
+            }
+        }
     }
 }
-


### PR DESCRIPTION
Fixes #46 by invoking the matched handlers catch() call on error, instead of just passing the result upwards.