### PR TITLE
(fix) Compatibility with Iron 0.0.11 fix: NoMatch error implementation fix, example fixes

### DIFF
--- a/examples/double_mount.rs
+++ b/examples/double_mount.rs
@@ -1,8 +1,7 @@
 extern crate iron;
 extern crate mount;
 
-use iron::{Iron, Request, Response, IronResult, Url, Set};
-use iron::response::modifiers::{Body, Status};
+use iron::{Iron, Request, Response, IronResult, Url};
 use iron::status;
 
 use mount::{Mount, OriginalUrl};
@@ -12,7 +11,7 @@ fn level_two(req: &mut Request) -> IronResult<Response> {
         Some(url) => println!("Original URL: {}", url),
         None => println!("Error: No original URL found.")
     }
-    Ok(Response::new().set(Status(status::Ok)).set(Body("Welcome to Level 2.")))
+    Ok(Response::with((status::Ok, "Welcome to Level 2.")))
 }
 
 fn main() {

--- a/examples/mount.rs
+++ b/examples/mount.rs
@@ -1,20 +1,19 @@
 extern crate iron;
 extern crate mount;
 
-use iron::{Iron, Request, Response, IronResult, Set};
-use iron::response::modifiers::{Body, Status};
+use iron::{Iron, Request, Response, IronResult};
 use iron::status;
 
 use mount::Mount;
 
 fn send_hello(req: &mut Request) -> IronResult<Response> {
     println!("Running send_hello handler, URL path: {}", req.url.path);
-    Ok(Response::new().set(Status(status::Ok)).set(Body("Hello!")))
+    Ok(Response::with((status::Ok, "Hello!")))
 }
 
 fn intercept(req: &mut Request) -> IronResult<Response> {
     println!("Running intercept handler, URL path: {}", req.url.path);
-    Ok(Response::new().set(Status(status::Ok)).set(Body("Blocked!")))
+    Ok(Response::with((status::Ok, "Blocked!")))
 }
 
 fn main() {

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -1,4 +1,5 @@
-use iron::{Handler, Response, Request, IronResult, IronError, Url, Error};
+use std::error::Error;
+use iron::{Handler, Response, Request, IronResult, IronError, Url};
 use iron::typemap::Assoc;
 use sequence_trie::SequenceTrie;
 
@@ -32,7 +33,7 @@ struct Match {
 pub struct NoMatch;
 
 impl Error for NoMatch {
-    fn name(&self) -> &'static str { "No Match" }
+    fn description(&self) -> &'static str { "No Match" }
 }
 
 impl Mount {


### PR DESCRIPTION
Current build fails with:

```
/home/tadas/src/mount/src/mount.rs:35:5: 35:50 error: method `name` is not a member of trait `Error`
/home/tadas/src/mount/src/mount.rs:35     fn name(&self) -> &'static str { "No Match" }
                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
error: aborting due to previous error
Could not compile `mount`.
```
