### PR TITLE
Fix for Rust alpha and latest Iron

### DIFF
--- a/examples/double_mount.rs
+++ b/examples/double_mount.rs
@@ -1,13 +1,13 @@
 extern crate iron;
 extern crate mount;
 
-use iron::{Iron, Request, Response, IronResult, Url};
+use iron::{Iron, Request, Response, IronResult};
 use iron::status;
 
 use mount::{Mount, OriginalUrl};
 
 fn level_two(req: &mut Request) -> IronResult<Response> {
-    match req.extensions.get::<OriginalUrl, Url>() {
+    match req.extensions.get::<OriginalUrl>() {
         Some(url) => println!("Original URL: {}", url),
         None => println!("Error: No original URL found.")
     }

--- a/examples/mount.rs
+++ b/examples/mount.rs
@@ -7,12 +7,12 @@ use iron::status;
 use mount::Mount;
 
 fn send_hello(req: &mut Request) -> IronResult<Response> {
-    println!("Running send_hello handler, URL path: {}", req.url.path);
+    println!("Running send_hello handler, URL path: {:?}", req.url.path);
     Ok(Response::with((status::Ok, "Hello!")))
 }
 
 fn intercept(req: &mut Request) -> IronResult<Response> {
-    println!("Running intercept handler, URL path: {}", req.url.path);
+    println!("Running intercept handler, URL path: {:?}", req.url.path);
     Ok(Response::with((status::Ok, "Blocked!")))
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![crate_name = "mount"]
 #![deny(missing_docs)]
 #![deny(warnings)]
-#![feature(macro_rules)]
+#![allow(unstable)]
 
 //! `Mount` provides mounting middleware for the Iron framework.
 


### PR DESCRIPTION
This pr fixes mount for Rust alpha and Assoc changes. Unfortunately tests still won't pass because of 
https://github.com/rust-lang/rust/issues/20676

```
 internal compiler error: static call to invalid vtable: VtableObject(VtableObject(object_ty=error::Error + 'static))
```