### PR TITLE
Update url dependency version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,4 @@ license = "MIT"
 
 [dependencies]
 iron = { version = "0.2", default-features = false }
-url = "0.2"
 sequence_trie = "0.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@
 //! `Mount` provides mounting middleware for the Iron framework.
 
 extern crate iron;
-extern crate url;
 extern crate sequence_trie;
 
 pub use mount::{Mount, OriginalUrl};


### PR DESCRIPTION
There's no reason to depend on such an old version, and that means that most non-trivial programs using mount end up with both url 0.2 and 0.5