### PR TITLE
Upgrade SequenceTrie to the latest version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ keywords = ["iron", "web", "handler", "routing"]
 
 [dependencies]
 iron = "0.4"
-sequence_trie = "0.0"
+sequence_trie = "0.2"

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -62,17 +62,18 @@ impl Mount {
     /// Existing handlers on the same route will be overwritten.
     pub fn mount<H: Handler>(&mut self, route: &str, handler: H) -> &mut Mount {
         // Parse the route into a list of strings. The unwrap is safe because strs are UTF-8.
-        let key: Vec<String> = Path::new(route).components().flat_map(|c|
+        let key: Vec<&str> = Path::new(route).components().flat_map(|c|
             match c {
                 Component::RootDir => None,
-                c => Some(c.as_os_str().to_str().unwrap().to_string())
-            }.into_iter()
+                c => Some(c.as_os_str().to_str().unwrap())
+            }
         ).collect();
 
         // Insert a match struct into the trie.
-        self.inner.insert(key.as_ref(), Match {
+        let match_length = key.len();
+        self.inner.insert(key, Match {
             handler: Box::new(handler) as Box<Handler>,
-            length: key.len()
+            length: match_length,
         });
         self
     }


### PR DESCRIPTION
The `sequence_trie` package has undergone some recent API changes, and it would be cool if Iron's mount could be updated to use the new API.

At the moment this PR depends on a further modification of `sequence_trie`: https://github.com/michaelsproul/rust_sequence_trie/pull/27, which I hope to get reviewed shortly.

Interestingly, it allows us to avoid allocations, by passing a `Vec<&str>` to `insert`, rather than a `Vec<String>`. We could avoid allocating the `Vec` entirely if the length weren't required up-front, but I don't think we need to worry about this for now.