### PR TITLE
(feat) Added mount! macro to build mounts.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,4 +10,4 @@ extern crate sequence_trie;
 pub use mount::{Mount, OriginalUrl};
 
 mod mount;
-
+mod macros;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,24 @@
+/// Create a set of mounts.
+///
+/// E.g. if you had a directory to serve images from:
+///
+/// ```ignore
+/// let mount = mount!("/images" => handler_for_image_dir);
+/// ```
+///
+/// Is equivalent to:
+///
+/// ```ignore
+/// let mut mount = Mount::new();
+/// mount.mount("/images", handler_for_image_dir);
+/// ```
+///
+/// You may provide multiple mappings, comma-delimited.
+#[macro_export]
+macro_rules! mount {
+    ($($path:expr => $handler:expr),+ $(,)*) => ({
+        let mut mount = $crate::Mount::new();
+        $(mount.mount($path, $handler);)*
+        mount
+    });
+}


### PR DESCRIPTION
I saw that #79 hasn't gotten attention in months and I also wanted this feature.

This adds a mount! like the router! macro from the router crate. Its only value is that I can write 

````rust
mount!("/assets" => Static::new("target/assets"))
````

in places I previously had to write

````rust
{
    let mount = Mount::new();
    mount.mount("/assets", Static::new("target/assets"));
    mount
}
````