### PR TITLE
Export NoMatch error for pub

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@
 extern crate iron;
 extern crate sequence_trie;
 
-pub use mount::{Mount, OriginalUrl};
+pub use mount::{Mount, OriginalUrl, NoMatch};
 
 mod mount;
-


### PR DESCRIPTION
@untitaker 

Exporting NoMatch error, needed for handling mounted rout no match errors.