### PR TITLE
Update for iron 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 name = "mount"
 authors = ["Jonathan Reem <jonathan.reem@gmail.com>"]
-version = "0.3.0"
+version = "0.4.0"
 description = "Mounting middleware for Iron."
 repository = "https://github.com/iron/mount"
 documentation = "http://ironframework.io/doc/mount/index.html"
@@ -10,5 +10,5 @@ license = "MIT"
 keywords = ["iron", "web", "handler", "routing"]
 
 [dependencies]
-iron = "0.5"
-sequence_trie = "0.2"
+iron = "0.6"
+sequence_trie = "0.3"


### PR DESCRIPTION
* Bump sequence_trie to newest minor version (no API changes)
* Bump crate version for release

CC @untitaker. Maybe merge this other PR before?: https://github.com/iron/mount/pull/94